### PR TITLE
Added `predicate` kwargs to `broadcast` and `publish` for better UX

### DIFF
--- a/src/webshocket/websocket.py
+++ b/src/webshocket/websocket.py
@@ -19,6 +19,7 @@ from .typing import (
     RateLimitConfig,
     RPC_Predicate,
 )
+
 from .enum import ConnectionState, PacketSource, ServerState, RPCErrorCode, ClientType
 from .packets import Packet, RPCRequest, serialize, deserialize
 from .connection import ClientConnection

--- a/src/webshocket/websocket.pyi
+++ b/src/webshocket/websocket.pyi
@@ -4,7 +4,7 @@ from picows import WSTransport
 
 from typing import Optional, Iterable, Union, Any, Callable, Awaitable, Self, TypeVar, Generic
 from .handler import WebSocketHandler, DefaultWebSocketHandler
-from .typing import RPC_Function
+from .typing import RPC_Function, RPC_Predicate
 from .connection import ClientConnection
 from .packets import Packet, RPCResponse
 from .enum import ConnectionState, ServerState
@@ -47,12 +47,14 @@ class server(Generic[H]):
         self,
         data: Union[str | bytes, Packet],
         exclude: Optional[tuple["ClientConnection", ...]] = None,
+        predicate: Optional[RPC_Predicate] = None,
     ) -> None: ...
     def publish(
         self,
         channel: str | Iterable[str],
         data: Union[str | bytes, Packet],
         exclude: Optional[tuple["ClientConnection", ...]] = None,
+        predicate: Optional[RPC_Predicate] = None,
     ) -> None: ...
     async def _handler(self, transport: WSTransport, listener: picows_server.ServerClientListener) -> None: ...
     async def accept(self) -> ClientConnection: ...

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,4 +1,3 @@
-from typing import final
 import picows
 import webshocket
 import pytest

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,6 +1,9 @@
+from typing import final
 import picows
 import webshocket
 import pytest
+
+from webshocket.exceptions import ReceiveTimeoutError
 
 HOST, PORT = "127.0.0.1", 5000
 
@@ -52,3 +55,30 @@ async def test_max_connection() -> None:
 
     await server.close()
     await client1.close()
+
+
+@pytest.mark.asyncio
+async def test_handler_pubsub_prequisite() -> None:
+    @webshocket.rpc_method()
+    async def get_admin(connection: webshocket.ClientConnection):
+        connection.admin = True
+
+    try:
+        server = webshocket.WebSocketServer(HOST, PORT, max_connection=2)
+        server.register_rpc_method(get_admin)
+        await server.start()
+
+        client_admin = await webshocket.WebSocketClient(f"ws://{HOST}:{PORT}").connect()
+        client_normal = await webshocket.WebSocketClient(f"ws://{HOST}:{PORT}").connect()
+        await client_admin.send_rpc("get_admin")
+
+        server.broadcast("Admin-exclusive broadcast", predicate=webshocket.Is("admin"))
+
+        response_admin = await client_admin.recv()
+        assert response_admin.data == "Admin-exclusive broadcast"
+
+        with pytest.raises(ReceiveTimeoutError):
+            _response_normal = await client_normal.recv(timeout=1)
+
+    finally:
+        await server.close()

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -11,7 +11,7 @@ from webshocket.exceptions import ReceiveTimeoutError, RateLimitError
 class _TestRpcHandler(webshocket.WebSocketHandler):
     async def on_receive(self, connection: webshocket.ClientConnection, packet: webshocket.Packet):
         if packet.source != PacketSource.RPC and packet.data is not None:
-            await connection.send(packet.data)
+            connection.send(packet.data)
         else:
             pass
 


### PR DESCRIPTION
before:
```py
await self.broadcast(
    f"User '{connection.session_state['username']}' has left the chat.",
    exclude=tuple(
        conn for conn in self.clients if connection.session_state.get("username") is None
    ),
)
``` 

after: 
```py
await self.broadcast(
    f"User '{connection.session_state['username']}' has left the chat.",
    predicate=Has("username")
)
```